### PR TITLE
Modal dismission onclick + fixes for CustomLinkNode exports to markdown

### DIFF
--- a/components/markdownEditor/Editor.tsx
+++ b/components/markdownEditor/Editor.tsx
@@ -8,6 +8,7 @@ import { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";
 import LexicalErrorBoundary from "@lexical/react/LexicalErrorBoundary";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
+import { LexicalNode } from "lexical";
 import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
 import { TRANSFORMERS, $convertToMarkdownString, $convertFromMarkdownString } from "@lexical/markdown";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
@@ -59,8 +60,14 @@ export function Editor({ value, onChange = () => { }, mode = "interactive", text
       TableCellNode,
       TableRowNode,
       AutoLinkNode,
+      LinkNode,
       CustomLinkNode,
-      LinkNode
+      {
+        replace: LinkNode,
+        with: (node: LexicalNode) => {
+          return new CustomLinkNode(node.__url, node.__target, []);
+        },
+      },
     ]
   };
 
@@ -105,7 +112,7 @@ export function Editor({ value, onChange = () => { }, mode = "interactive", text
             <HistoryPlugin />
             <ListPlugin />
             <CustomAutoLinkPlugin />
-            
+
             <ListMaxIndentLevelPlugin maxDepth={7} />
             <ReadOnlyPlugin isDisabled={mode === "preview"} />
             <ControlledEditorPlugin value={value} isPreview={mode === "preview"} />

--- a/components/markdownEditor/plugins/ToolbarPlugin.tsx
+++ b/components/markdownEditor/plugins/ToolbarPlugin.tsx
@@ -337,6 +337,8 @@ export function ToolbarPlugin(props: Props) {
     [editor, selectedElementKey]
   );
 
+  useEffect(() => console.log(linkUrl), [linkUrl]);
+
   const insertLink = useCallback(() => {
     editor.dispatchCommand(TOGGLE_CUSTOM_LINK_NODE_COMMAND, {
       url: linkUrl,
@@ -391,7 +393,7 @@ export function ToolbarPlugin(props: Props) {
           <button onClick={insertLink} className={"toolbar-item spaced " + (isLink ? "active" : "")} aria-label="Insert Link">
             <i className="format link" />
           </button>
-          {isLink && createPortal(<FloatingLinkEditor linkUrl={linkUrl} setLinkUrl={setLinkUrl} classNamesList={classNamesList} setClassNamesList={setClassNamesList} targetAttribute={targetAttribute} setTargetAttribute={setTargetAttribute} />, document.body)}
+          {isLink && createPortal(<FloatingLinkEditor selectedElementKey={selectedElementKey} linkUrl={linkUrl} setLinkUrl={setLinkUrl} classNamesList={classNamesList} setClassNamesList={setClassNamesList} targetAttribute={targetAttribute} setTargetAttribute={setTargetAttribute} />, document.body)}
         </>)}
       <Divider />
       <button onClick={() => { props.goFullScreen() }} className="toolbar-item spaced" aria-label="Full Screen">

--- a/components/markdownEditor/plugins/customLink/CustomLinkNodePlugin.tsx
+++ b/components/markdownEditor/plugins/customLink/CustomLinkNodePlugin.tsx
@@ -17,7 +17,7 @@ const CustomLinkNodePlugin: FC = () => {
       (props: LinkCustomizationAttributes) => {
         toggleCustomLinkNode({
           ...props,
-          getNodeByKey: (key: string) => editor.getElementByKey(key),
+          getNodeByKey: (key: string) => editor.getElementByKey(key)
         });
 
         return true;

--- a/components/markdownEditor/plugins/customLink/CustomLinkNodeTransformer.tsx
+++ b/components/markdownEditor/plugins/customLink/CustomLinkNodeTransformer.tsx
@@ -9,13 +9,14 @@ import {
 
 export const CUSTOM_LINK_NODE_TRANSFORMER: TextMatchTransformer = {
   dependencies: [CustomLinkNode],
-  export: (node: LexicalNode) => {
+  export: (node: LexicalNode, _, dom) => {
+    console.log(node, _, dom);
     if (!$isCustomLinkNode(node)) {
       return null;
     }
 
-    const linkContent = `[${node.getTextContent()}](${node.getURL()}){:target="${node.getTarget()}" ${node
-      .getClassNames()
+    const linkContent = `[${node.getTextContent()}](${node.__url}){:target="${node.__target}" ${node
+      .__classNames
       .map((className: string) => "." + className)
       .join(" ")}}`;
 

--- a/components/markdownEditor/plugins/customLink/FloatingLinkEditor.types.ts
+++ b/components/markdownEditor/plugins/customLink/FloatingLinkEditor.types.ts
@@ -7,4 +7,5 @@ export interface FloatingLinkEditorProps {
   setTargetAttribute: Dispatch<SetStateAction<string>>;
   classNamesList: Array<string>;
   setClassNamesList: (value: Array<string>) => void;
+  selectedElementKey: string | null;
 }


### PR DESCRIPTION
FloatingLinkEditor dismission with Save button when onClick is added; export to markdown string returns a custom link node with proper className names and other attributes